### PR TITLE
put catkin_package() before add_executable and add_library , delete pcl depend form package.xml

### DIFF
--- a/pr2_navigation_perception/CMakeLists.txt
+++ b/pr2_navigation_perception/CMakeLists.txt
@@ -4,16 +4,18 @@ project(pr2_navigation_perception)
 
 find_package(catkin REQUIRED COMPONENTS semantic_point_annotator laser_filters pr2_machine topic_tools pr2_navigation_self_filter geometry_msgs dynamic_reconfigure sensor_msgs roscpp tf filters message_filters laser_geometry laser_tilt_controller_filter pcl_ros)
 
-include_directories(${PROJECT_SOURCE_DIR}/config/pr2_laser_filters/include ${catkin_INCLUDE_DIRS})
-
-add_library(pr2_point_cloud_filters config/pr2_laser_filters/src/pr2_point_cloud_filters.cpp)
-
 catkin_package(
     DEPENDS 
     CATKIN-DEPENDS semantic_point_annotator laser_filters pr2_machine topic_tools pr2_navigation_self_filter geometry_msgs dynamic_reconfigure sensor_msgs roscpp tf filters message_filters laser_geometry laser_tilt_controller_filter pcl_ros
     INCLUDE_DIRS config/pr2_laser_filters/include
     LIBRARIES pr2_point_cloud_filters
 )
+
+include_directories(${PROJECT_SOURCE_DIR}/config/pr2_laser_filters/include ${catkin_INCLUDE_DIRS})
+
+
+add_library(pr2_point_cloud_filters config/pr2_laser_filters/src/pr2_point_cloud_filters.cpp)
+target_link_libraries(pr2_point_cloud_filters ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES})
 
 install(TARGETS pr2_point_cloud_filters
    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/pr2_navigation_perception/CMakeLists.txt
+++ b/pr2_navigation_perception/CMakeLists.txt
@@ -13,7 +13,6 @@ catkin_package(
 
 include_directories(${PROJECT_SOURCE_DIR}/config/pr2_laser_filters/include ${catkin_INCLUDE_DIRS})
 
-
 add_library(pr2_point_cloud_filters config/pr2_laser_filters/src/pr2_point_cloud_filters.cpp)
 target_link_libraries(pr2_point_cloud_filters ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES})
 

--- a/pr2_navigation_perception/package.xml
+++ b/pr2_navigation_perception/package.xml
@@ -26,7 +26,6 @@
   <build_depend>message_filters</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>laser_tilt_controller_filter</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
 
   <run_depend>semantic_point_annotator</run_depend>
@@ -43,7 +42,6 @@
   <run_depend>message_filters</run_depend>
   <run_depend>laser_geometry</run_depend>
   <run_depend>laser_tilt_controller_filter</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
 
   <!-- <test_depend>semantic_point_annotator</test_depend> -->
@@ -60,7 +58,6 @@
   <!-- <test_depend>message_filters</test_depend> -->
   <!-- <test_depend>laser_geometry</test_depend> -->
   <!-- <test_depend>laser_tilt_controller_filter</test_depend> -->
-  <!-- <test_depend>pcl</test_depend> -->
   <!-- <test_depend>pcl_ros</test_depend> -->
 
   <export>

--- a/pr2_navigation_self_filter/CMakeLists.txt
+++ b/pr2_navigation_self_filter/CMakeLists.txt
@@ -22,7 +22,6 @@ catkin_package(
     LIBRARIES pr2_navigation_geometric_shapes ${PROJECT_NAME}
 )
 
-
 #common commands for building c++ executables and libraries
 add_library(pr2_navigation_geometric_shapes src/load_mesh.cpp src/shapes.cpp src/bodies.cpp)
 

--- a/pr2_navigation_self_filter/CMakeLists.txt
+++ b/pr2_navigation_self_filter/CMakeLists.txt
@@ -14,6 +14,15 @@ add_definitions(${PCL_DEFINITIONS})
 
 find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf resource_retriever visualization_msgs pcl_ros)
 
+
+catkin_package(
+    DEPENDS bullet
+    CATKIN-DEPENDS roscpp tf filters sensor_msgs urdf resource_retriever visualization_msgs pcl_ros
+    INCLUDE_DIRS include
+    LIBRARIES pr2_navigation_geometric_shapes ${PROJECT_NAME}
+)
+
+
 #common commands for building c++ executables and libraries
 add_library(pr2_navigation_geometric_shapes src/load_mesh.cpp src/shapes.cpp src/bodies.cpp)
 
@@ -32,12 +41,6 @@ target_link_libraries(self_filter pr2_navigation_geometric_shapes)
 include_directories(include ${bullet_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 target_link_libraries(pr2_navigation_geometric_shapes ${bullet_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
 
-catkin_package(
-    DEPENDS bullet
-    CATKIN-DEPENDS roscpp tf filters sensor_msgs urdf resource_retriever visualization_msgs pcl_ros
-    INCLUDE_DIRS include
-    LIBRARIES pr2_navigation_geometric_shapes ${PROJECT_NAME}
-)
 
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/semantic_point_annotator/CMakeLists.txt
+++ b/semantic_point_annotator/CMakeLists.txt
@@ -21,11 +21,9 @@ catkin_package(
     LIBRARIES
 )
 
-
 add_executable(sac_inc_ground_removal_node src/sac_inc_ground_removal_standalone.cpp src/sac/sac.cpp src/sac/ransac.cpp src/sac/sac_model.cpp src/sac/sac_model_line.cpp)
 include_directories(include/${PROJECT_NAME} ${Boost_INCLUDE_DIRS} ${PC_EIGEN_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS}  ${caktin_INCLUDE_DIRS})
 target_link_libraries(sac_inc_ground_removal_node ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
-
 
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/semantic_point_annotator/CMakeLists.txt
+++ b/semantic_point_annotator/CMakeLists.txt
@@ -14,16 +14,18 @@ add_definitions(${PC_EIGEN_CFLAGS_OTHER})
 find_package( PCL REQUIRED )
 add_definitions(${PCL_DEFINITIONS})
 
-add_executable(sac_inc_ground_removal_node src/sac_inc_ground_removal_standalone.cpp src/sac/sac.cpp src/sac/ransac.cpp src/sac/sac_model.cpp src/sac/sac_model_line.cpp)
-include_directories(include/${PROJECT_NAME} ${Boost_INCLUDE_DIRS} ${PC_EIGEN_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS}  ${caktin_INCLUDE_DIRS})
-target_link_libraries(sac_inc_ground_removal_node ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
-
 catkin_package(
     DEPENDS pcl eigen
     CATKIN-DEPENDS roscpp tf pcl_ros
     INCLUDE_DIRS include
     LIBRARIES
 )
+
+
+add_executable(sac_inc_ground_removal_node src/sac_inc_ground_removal_standalone.cpp src/sac/sac.cpp src/sac/ransac.cpp src/sac/sac_model.cpp src/sac/sac_model_line.cpp)
+include_directories(include/${PROJECT_NAME} ${Boost_INCLUDE_DIRS} ${PC_EIGEN_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS}  ${caktin_INCLUDE_DIRS})
+target_link_libraries(sac_inc_ground_removal_node ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
+
 
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/semantic_point_annotator/package.xml
+++ b/semantic_point_annotator/package.xml
@@ -16,13 +16,11 @@
   <build_depend>eigen</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
 
   <run_depend>eigen</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
 
   <!-- <test_depend>roscpp</test_depend> -->


### PR DESCRIPTION
According to http://wiki.ros.org/catkin/CMakeLists.txt#catkin_package.28.29,
catkin_package() should be below

```
This function must be called before declaring any targets with add_library() or add_executable().
```

Also I deleted pcl depends from some package.xml s
