### PR TITLE
Fix self filter, checking mask value

### DIFF
--- a/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_see_filter.h
+++ b/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_see_filter.h
@@ -201,7 +201,10 @@ public:
 	
     for (unsigned int i = 0 ; i < np ; ++i)
     {
-      data_out.points.push_back(data_in.points[i]);
+      if (keep[i] == robot_self_filter::OUTSIDE)
+      {
+        data_out.points.push_back(data_in.points[i]);
+      }
     }
   }
 


### PR DESCRIPTION
fix self filter to work. 
this patch is confirmed on PR2 with hydro.

self_filter need to verify `keep` (mask generated by robot model) value to know if the points is inside of robot model or not.

Please checkout the codes around here: https://github.com/uos/arm_navigation/blob/master/robot_self_filter%2Finclude%2Frobot_self_filter%2Fself_see_filter.h#L264
