### PR TITLE
- add_library must be called after catkin_package, see  http://wiki.ros.org/catkin/CMakeLists.txt#catkin_package.28.29

### DIFF
--- a/laser_tilt_controller_filter/CMakeLists.txt
+++ b/laser_tilt_controller_filter/CMakeLists.txt
@@ -4,11 +4,8 @@ project(laser_tilt_controller_filter)
 
 find_package(catkin REQUIRED COMPONENTS filters sensor_msgs roscpp pluginlib pr2_msgs)
 
-add_library(laser_tilt_controller_filter src/laser_tilt_controller_filter.cpp)
-
 find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-target_link_libraries(laser_tilt_controller_filter ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 catkin_package(
     DEPENDS 
@@ -16,6 +13,9 @@ catkin_package(
     INCLUDE_DIRS include
     LIBRARIES laser_tilt_controller_filter
 )
+
+add_library(laser_tilt_controller_filter src/laser_tilt_controller_filter.cpp)
+target_link_libraries(laser_tilt_controller_filter ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
see  http://wiki.ros.org/catkin/CMakeLists.txt#catkin_package.28.29
