### PR TITLE
[pr2_navigation_self_filter] Support collada dae mesh file as well as stl files

### DIFF
--- a/pr2_navigation_self_filter/CMakeLists.txt
+++ b/pr2_navigation_self_filter/CMakeLists.txt
@@ -12,6 +12,30 @@ pkg_check_modules(bullet REQUIRED bullet)
 find_package( PCL REQUIRED )
 add_definitions(${PCL_DEFINITIONS})
 
+find_package(ASSIMP QUIET)
+if (NOT ASSIMP_FOUND)
+  pkg_check_modules(ASSIMP assimp)
+endif()
+if (ASSIMP_FOUND)
+  if( NOT ${ASSIMP_VERSION} VERSION_LESS "2.0.1150" )
+    add_definitions(-DASSIMP_UNIFIED_HEADER_NAMES)
+    message(STATUS "Assimp version has unified headers")
+  else()
+    message(STATUS "Assimp version does not have unified headers")
+  endif()
+  include_directories(${ASSIMP_INCLUDE_DIRS})
+  link_directories(${ASSIMP_LIBRARY_DIRS})
+else()
+  message(STATUS "could not find assimp (perhaps available thorugh ROS package?), so assimping assimp v2")
+  set(ASSIMP_LIBRARIES assimp)
+  set(ASSIMP_LIBRARY_DIRS)
+  set(ASSIMP_CXX_FLAGS)
+  set(ASSIMP_CFLAGS_OTHER)
+  set(ASSIMP_LINK_FLAGS)
+  set(ASSIMP_INCLUDE_DIRS)
+endif()
+
+
 find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscpp resource_retriever visualization_msgs pcl_ros)
 
 catkin_package(
@@ -25,19 +49,19 @@ catkin_package(
 add_library(pr2_navigation_geometric_shapes src/load_mesh.cpp src/shapes.cpp src/bodies.cpp)
 
 add_library(${PROJECT_NAME} src/self_mask.cpp)
-target_link_libraries(${PROJECT_NAME} pr2_navigation_geometric_shapes)
+target_link_libraries(${PROJECT_NAME} pr2_navigation_geometric_shapes assimp)
 
 
 add_executable(test_filter src/test_filter.cpp)
 target_link_libraries(test_filter ${PROJECT_NAME})
-target_link_libraries(test_filter pr2_navigation_geometric_shapes)
+target_link_libraries(test_filter pr2_navigation_geometric_shapes  assimp)
 
 add_executable(self_filter src/self_filter.cpp)
 target_link_libraries(self_filter ${PROJECT_NAME})
-target_link_libraries(self_filter pr2_navigation_geometric_shapes)
+target_link_libraries(self_filter pr2_navigation_geometric_shapes  assimp)
 
 include_directories(include ${bullet_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-target_link_libraries(pr2_navigation_geometric_shapes ${bullet_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(pr2_navigation_geometric_shapes ${bullet_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES}  assimp)
 
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_mask.h
+++ b/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_mask.h
@@ -36,6 +36,7 @@
 #include <pr2_navigation_self_filter/bodies.h>
 #include <tf/transform_listener.h>
 #include <boost/bind.hpp>
+#include <boost/filesystem.hpp>
 #include <string>
 #include <vector>
 
@@ -111,7 +112,14 @@ struct LinkInfo
 			    ROS_WARN("Retrieved empty mesh for resource '%s'", mesh->filename.c_str());
 			else
 			{
-			    result = shapes::createMeshFromBinaryStlData(reinterpret_cast<char*>(res.data.get()), res.size);
+			    boost::filesystem::path model_path(mesh->filename);
+			    std::string ext = model_path.extension().string();
+			    if (ext == ".dae" || ext == ".DAE") {
+			      result = shapes::createMeshFromBinaryDAE(mesh->filename.c_str());
+			    }
+			    else {
+			      result = shapes::createMeshFromBinaryStlData(reinterpret_cast<char*>(res.data.get()), res.size);
+			    }
 			    if (result == NULL)
 				ROS_ERROR("Failed to load mesh '%s'", mesh->filename.c_str());
 			}

--- a/pr2_navigation_self_filter/include/pr2_navigation_self_filter/shapes.h
+++ b/pr2_navigation_self_filter/include/pr2_navigation_self_filter/shapes.h
@@ -241,6 +241,11 @@ namespace shapes
 	recomputed and repeating vertices are identified. */
     Mesh* createMeshFromBinaryStlData(const char *data, unsigned int size);
 
+    /** \brief Load a mesh from a binary DAE file. Normals are
+	recomputed and repeating vertices are identified. */
+    Mesh* createMeshFromBinaryDAE(const char* filename);
+
+  
     /** \brief Create a copy of a shape */
     Shape* cloneShape(const Shape *shape);
 

--- a/pr2_navigation_self_filter/package.xml
+++ b/pr2_navigation_self_filter/package.xml
@@ -21,7 +21,8 @@
   <build_depend>resource_retriever</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
-
+  <build_depend>assimp-dev</build_depend>
+  
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>filters</run_depend>
@@ -31,7 +32,7 @@
   <run_depend>resource_retriever</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
-
+  <run_depend>assimp</run_depend>
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>tf</test_depend> -->
   <!-- <test_depend>filters</test_depend> -->


### PR DESCRIPTION
![self_filter_dae](https://cloud.githubusercontent.com/assets/40454/8223858/7c0620ee-15b8-11e5-9d66-ba76eb0556be.png)

PR2 mesh file is STL but urdf format support COLLADA dae as mesh too.
This patch supports DAE meshes in self_filter.

The picture shows the result of self filtering of robots which has dae meshes.

The implementation is based on rviz [mesh loader](https://github.com/ros-visualization/rviz/blob/indigo-devel/src/rviz/mesh_loader.cpp) and use assimp to load collada meshes.
