### PR TITLE
Change private member variable to protected in SelfMask

### DIFF
--- a/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_mask.h
+++ b/pr2_navigation_self_filter/include/pr2_navigation_self_filter/self_mask.h
@@ -409,7 +409,7 @@ struct LinkInfo
             frames.push_back(bodies_[i].name);
         }
 	
-    private:
+    protected:
 
 	/** \brief Free memory. */
 	void freeMemory(void)


### PR DESCRIPTION
I'd like to generate the derived class of SelfMask and access the member variables in the derived class.
Cloud you change these private member variables to protected?
