### PR TITLE
Set correct timestamp for self filtered cloud

### DIFF
--- a/pr2_navigation_self_filter/src/self_filter.cpp
+++ b/pr2_navigation_self_filter/src/self_filter.cpp
@@ -148,6 +148,7 @@ private:
       pcl::PointCloud<pcl::PointXYZRGB> out;
       self_filter_rgb_->updateWithSensorFrame(*cloud, out, sensor_frame_);
       pcl::toROSMsg(out, out2);
+      out2.header.stamp = cloud2->header.stamp;
       input_size = cloud->points.size();
       output_size = out.points.size();
     }
@@ -158,6 +159,7 @@ private:
       pcl::PointCloud<pcl::PointXYZ> out;
       self_filter_->updateWithSensorFrame(*cloud, out, sensor_frame_);
       pcl::toROSMsg(out, out2);
+      out2.header.stamp = cloud2->header.stamp;
       input_size = cloud->points.size();
       output_size = out.points.size();
     }


### PR DESCRIPTION
This is needed because pcl drops some value of timestamp.
So pcl::fromROSMsg and pcl::toROSMsg does not work to get correct timestamp.
