### PR TITLE
specify prefix for filter plugins

### DIFF
--- a/pr2_navigation_perception/config/laser_interpolation.yaml
+++ b/pr2_navigation_perception/config/laser_interpolation.yaml
@@ -1,3 +1,3 @@
 scan_filter_chain:
 - name: interpolation
-  type: InterpolationFilter
+  type: laser_filters/InterpolationFilter

--- a/pr2_navigation_perception/config/shadow_filter.yaml
+++ b/pr2_navigation_perception/config/shadow_filter.yaml
@@ -1,13 +1,13 @@
 scan_filter_chain:
 - name: shadows
-  type: ScanShadowsFilter
+  type: laser_filters/ScanShadowsFilter
   params:
     min_angle: 10
     max_angle: 170
     neighbors: 20
     window: 1
 - name: dark_shadows
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params: 
     lower_threshold: 100
     upper_threshold: 10000

--- a/pr2_navigation_perception/config/tilt_laser_filters.yaml
+++ b/pr2_navigation_perception/config/tilt_laser_filters.yaml
@@ -1,19 +1,19 @@
 scan_filter_chain:
 - name: shadows
-  type: ScanShadowsFilter
+  type: laser_filters/ScanShadowsFilter
   params:
     min_angle: 10
     max_angle: 170
     neighbors: 20
     window: 1
 - name: dark_shadows
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params: 
     lower_threshold: 100
     upper_threshold: 10000
     disp_histogram: 0
 - name: angular_bounds
-  type: LaserScanAngularBoundsFilter
+  type: laser_filters/LaserScanAngularBoundsFilter
   params:
     lower_angle: -1.22173048
     upper_angle: 1.22173048


### PR DESCRIPTION
The missing prefix has hazardous consequences due
to a series of unfortunate events involving the filters and the
laser_filters package..

See https://github.com/ros-perception/laser_filters/issues/50 for more details.

Fixes #26 