### PR TITLE
use less strict parameters for ground filtering

### DIFF
--- a/pr2_navigation_perception/ground_plane.xml
+++ b/pr2_navigation_perception/ground_plane.xml
@@ -4,7 +4,8 @@
   <remap from="cloud_ground_filtered" to="ground_object_cloud" />
   <param name="z_threshold" value="0.15" />
   <param name="sac_min_points_per_model" value="40" />
-  <param name="sac_distance_threshold" value="0.05" />
+  <param name="sac_distance_threshold" value="0.08" />
+  <param name="sac_fitting_distance_threshold" value="0.05" />
   <param name="planar_refine" value="1" />
 </node>
 </launch>


### PR DESCRIPTION
In our setup (an off-the-shelf PR2 with respect to these parts) the
previous parameters were too tight:
In many situations, especially when an obstacle split the ground-part
of a single laser-scan into two segments, one of these segments is not
picked up by the line-RANSAC with the old parameters.
Thus it ends up as an obstacle obstructing the local costmap of the
navigation.
With indigo, nobody else noticed this up to now because of a broken
filter-chain before that(see #27).