### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/laser_tilt_controller_filter/src/laser_tilt_controller_filter.cpp
+++ b/laser_tilt_controller_filter/src/laser_tilt_controller_filter.cpp
@@ -38,4 +38,4 @@
 
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(laser_tilt_controller_filter, LaserTiltControllerFilter, laser_tilt_controller_filter::LaserTiltControllerFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_tilt_controller_filter::LaserTiltControllerFilter, filters::FilterBase<sensor_msgs::LaserScan>)

--- a/pr2_navigation_perception/config/pr2_laser_filters/src/pr2_point_cloud_filters.cpp
+++ b/pr2_navigation_perception/config/pr2_laser_filters/src/pr2_point_cloud_filters.cpp
@@ -32,4 +32,4 @@
 #include "filters/filter_base.h"
 #include "pluginlib/class_list_macros.h"
 
-PLUGINLIB_DECLARE_CLASS(pr2_navigation_perception, PR2PointCloudFootprintFilterNew, pr2_laser_filters::PR2PointCloudFootprintFilterNew, filters::FilterBase<sensor_msgs::PointCloud2>)
+PLUGINLIB_EXPORT_CLASS(pr2_laser_filters::PR2PointCloudFootprintFilterNew, filters::FilterBase<sensor_msgs::PointCloud2>)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions