### PR TITLE
use `arg` for all parameters for ground filtering

### DIFF
--- a/pr2_navigation_perception/ground_plane.xml
+++ b/pr2_navigation_perception/ground_plane.xml
@@ -1,10 +1,14 @@
 <launch>
+<arg name="z_threshold" value="0.15" />
+<arg name="sac_min_points_per_model" value="40" />
+<arg name="sac_distance_threshold" value="0.05" />
+<arg name="planar_refine" value="1" />
 <node pkg="semantic_point_annotator" type="sac_inc_ground_removal_node" name="sac_ground_removal" machine="c2" >
   <remap from="tilt_laser_cloud_filtered" to="tilt_scan_filtered" />
   <remap from="cloud_ground_filtered" to="ground_object_cloud" />
-  <param name="z_threshold" value="0.15" />
-  <param name="sac_min_points_per_model" value="40" />
-  <param name="sac_distance_threshold" value="0.05" />
-  <param name="planar_refine" value="1" />
+  <param name="z_threshold" value="$(arg z_threshold)" />
+  <param name="sac_min_points_per_model" value="$(arg sac_min_points_per_model)" />
+  <param name="sac_distance_threshold" value="$(arg sac_distance_threshold)" />
+  <param name="planar_refine" value="$(arg planar_refine)" />
 </node>
 </launch>

--- a/pr2_navigation_perception/ground_plane.xml
+++ b/pr2_navigation_perception/ground_plane.xml
@@ -1,14 +1,14 @@
 <launch>
-<arg name="z_threshold" value="0.15" />
-<arg name="sac_min_points_per_model" value="40" />
-<arg name="sac_distance_threshold" value="0.05" />
-<arg name="planar_refine" value="1" />
-<node pkg="semantic_point_annotator" type="sac_inc_ground_removal_node" name="sac_ground_removal" machine="c2" >
-  <remap from="tilt_laser_cloud_filtered" to="tilt_scan_filtered" />
-  <remap from="cloud_ground_filtered" to="ground_object_cloud" />
-  <param name="z_threshold" value="$(arg z_threshold)" />
-  <param name="sac_min_points_per_model" value="$(arg sac_min_points_per_model)" />
-  <param name="sac_distance_threshold" value="$(arg sac_distance_threshold)" />
-  <param name="planar_refine" value="$(arg planar_refine)" />
-</node>
+  <arg name="z_threshold" value="0.15" />
+  <arg name="sac_min_points_per_model" value="40" />
+  <arg name="sac_distance_threshold" value="0.05" />
+  <arg name="planar_refine" value="1" />
+  <node pkg="semantic_point_annotator" type="sac_inc_ground_removal_node" name="sac_ground_removal" machine="c2" >
+    <remap from="tilt_laser_cloud_filtered" to="tilt_scan_filtered" />
+    <remap from="cloud_ground_filtered" to="ground_object_cloud" />
+    <param name="z_threshold" value="$(arg z_threshold)" />
+    <param name="sac_min_points_per_model" value="$(arg sac_min_points_per_model)" />
+    <param name="sac_distance_threshold" value="$(arg sac_distance_threshold)" />
+    <param name="planar_refine" value="$(arg planar_refine)" />
+  </node>
 </launch>


### PR DESCRIPTION
rewrited version of #29

@v4n, if we could not find good parameters for ground filtering, how about add `args` and let users to set arbitrary values?