### PR TITLE
remove sim_period parameter: it does not exist (anymore?)

### DIFF
--- a/pr2_navigation_config/move_base/dwa_local_planner.yaml
+++ b/pr2_navigation_config/move_base/dwa_local_planner.yaml
@@ -33,8 +33,6 @@ vx_samples: 3
 vy_samples: 10
 vtheta_samples: 20
 
-sim_period: 0.1
-
 xy_goal_tolerance: 0.2
 yaw_goal_tolerance: 0.17
 


### PR DESCRIPTION
I found an error message related to this in kinetic a long time ago and just managed to push it as a pull-request.

@davefeilseifer 