### PR TITLE
do not publish voxelmap

### DIFF
--- a/pr2_navigation_global/config/local_costmap_params.yaml
+++ b/pr2_navigation_global/config/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 local_costmap:
   #Independent settings for the local costmap
-  publish_voxel_map: true
+  publish_voxel_map: false
   global_frame: odom_combined
   robot_base_frame: base_footprint
   update_frequency: 5.0


### PR DESCRIPTION
This saves some cycles of the memcpy to the message and thus frees some resources in move_base which runs close to the minimum required cycle time even on the "indigo upgrade" servers.

I thought this reasonable to reduce additional delays.

@davefeilseifer 