### PR TITLE
fix build with overlayed catkin workspace

### DIFF
--- a/pr2_navigation_self_filter/CMakeLists.txt
+++ b/pr2_navigation_self_filter/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pr2_navigation_self_filter)
 
+find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscpp resource_retriever visualization_msgs pcl_ros)
+
 find_package(PkgConfig REQUIRED)
 
 find_package(Boost REQUIRED)
@@ -39,8 +41,6 @@ else()
   set(ASSIMP_INCLUDE_DIRS)
 endif()
 
-
-find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscpp resource_retriever visualization_msgs pcl_ros)
 
 catkin_package(
     DEPENDS bullet


### PR DESCRIPTION
catkin should be the first find_packaged component. Usually it's no problem to do it any other way, but apparently one of the intermediate ones can modify the state in such a way that the correct catkin instance is skipped and the overlayed one is used...

As this change is not harmful for anything else but addresses an edge-case, I will merge it.